### PR TITLE
persist split state across page-reloads

### DIFF
--- a/app/src/components/SplitPane.vue
+++ b/app/src/components/SplitPane.vue
@@ -17,9 +17,15 @@
 
 <script>
 export default {
+  props: {
+    initialSplit: {
+      type: Number,
+      default: 50,
+    },
+  },
   data () {
     return {
-      split: 50,
+      split: this.initialSplit,
       dragging: false
     }
   },
@@ -38,6 +44,7 @@ export default {
     },
     dragEnd () {
       this.dragging = false
+      this.$emit('dragend', this.split)
     }
   }
 }

--- a/app/src/index.html
+++ b/app/src/index.html
@@ -77,7 +77,7 @@
         <button class="btn btn-lg btn-outline-primary px-5 ml-auto" type="submit" :disabled="!model.code">Run</button>
       </nav>
       <div class="d-flex flex-grow py-3">
-        <split-pane class="splitpane" draggerClass="col">
+        <split-pane class="splitpane" draggerClass="col" :initial-split="model.split" v-on:dragend="saveSplit">
           <validate slot="left" auto-label class="col h-100 right-padding-0" :class="fieldClassName(formstate.code)">
             <div id="code-box" class="text-left">
               <codemirror id="code" name="code" v-model="model.code" :options="editorOptions" ref="codeEditor"

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -24,7 +24,8 @@ const defaults = {
   type: 'file',
   code: '',
   file: '',
-  files: []
+  files: [],
+  split: 50
 };
 const valid = {
   code: true
@@ -44,6 +45,7 @@ const model = Object.assign({}, {
   type: stored.type,
   code: stored.code,
   file: stored.file,
+  split: +stored.split,
   files: defaults.files
 });
 
@@ -80,7 +82,7 @@ new Vue({
 
   data() {
     return {
-      
+
       formstate: {},
       model: model,
       loading: {
@@ -207,7 +209,7 @@ new Vue({
       if (this.formstate.$valid) {
         this.updateProgress(this, 0);
         body.code = this.model.code;
-        localStorage.setItem('es7-model', JSON.stringify(this.model));
+        this.persist();
 
         axios.post('/code', body)
           .then(res => {
@@ -221,7 +223,7 @@ new Vue({
             this.setLoadingError(true);
 
             if (stored) {
-              localStorage.setItem('es7-model', JSON.stringify(stored));
+              this.persist(stored);
               this.model = Object.assign({}, this.model, stored);
             } else {
               localStorage.removeItem('es7-model');
@@ -241,6 +243,15 @@ new Vue({
             console.log(e); // eslint-disable-line no-console
           });
       }
-    }
+    },
+
+    saveSplit(splitValue) {
+      this.model.split = +splitValue;
+      this.persist();
+    },
+
+    persist(state) {
+      localStorage.setItem('es7-model', JSON.stringify(state || this.model));
+    },
   }
 });


### PR DESCRIPTION
- split-pane component: expose initial-split prop, emit current split value on drag-end
- store the current split state in the local storage, to restore it after page reload